### PR TITLE
Fix for file name check for .pdf templates when request.format=pdf

### DIFF
--- a/src/play/modules/pdf/PDF.java
+++ b/src/play/modules/pdf/PDF.java
@@ -57,7 +57,7 @@ public class PDF {
         public String ALL_PAGES = null;
         public String EVEN_PAGES = null;
         public String ODD_PAGES = null;
-        
+
         public String filename = null;
 
         public IHtmlToPdfTransformer.PageSize pageSize = IHtmlToPdfTransformer.A4P;
@@ -74,7 +74,7 @@ public class PDF {
 			this.template = template;
 			this.options = options;
     	}
-    	
+
     	public PDFDocument(String template, Options options, Object... args) {
     		this(template, options);
             for (Object o : args) {
@@ -93,11 +93,11 @@ public class PDF {
 		public PDFDocument() {
 		}
     }
-    
+
     public static class MultiPDFDocuments {
     	public List<PDFDocument> documents = new LinkedList<PDFDocument>();
     	public String filename;
-    	
+
 		public MultiPDFDocuments(String filename) {
 			this.filename = filename;
 		}
@@ -121,7 +121,7 @@ public class PDF {
 			return this;
 		}
     }
-    
+
     /**
      * Render the corresponding template
      *
@@ -148,7 +148,7 @@ public class PDF {
 			throw new UnexpectedException(e);
 		}
     }
-    
+
     /**
      * Render the corresponding template into a file
      * @param out the stream to render to, or null to render to the current Response object
@@ -160,7 +160,7 @@ public class PDF {
 
         PDFDocument singleDoc = new PDFDocument();
         MultiPDFDocuments docs = null;
-        
+
         if(args.length > 0){
         	if (args[0] instanceof String && LocalvariablesNamesEnhancer.LocalVariablesNamesTracer.getAllLocalVariableNames(args[0]).isEmpty()) {
         		singleDoc.template = args[0].toString();
@@ -186,7 +186,7 @@ public class PDF {
         	else
         		docs.filename = FilenameUtils.getBaseName(singleDoc.template) + ".pdf";
         }
-        
+
         renderTemplateAsPDF(out, docs, args);
     }
 
@@ -198,8 +198,18 @@ public class PDF {
             }
             templateName = templateName.replace(".", "/") + "." + (format == null ? "html" : format);
         }
-        VirtualFile template = Play.getVirtualFile(templateName);
-        if (template == null || !template.exists()) {
+        Boolean templateExists = false;
+        for (VirtualFile vf : Play.templatesPath) {
+            if (vf == null) {
+                continue;
+            }
+            VirtualFile tf = vf.child(templateName);
+            if (tf.exists()) {
+                templateExists = true;
+                break;
+            }
+        }
+        if (!templateExists) {
             if (templateName.lastIndexOf("." + format) != -1) {
             	templateName = templateName.substring(0, templateName.lastIndexOf("." + format)) + ".html";
             }
@@ -244,7 +254,7 @@ public class PDF {
             }
             StackTraceElement element = PlayException.getInterestingStrackTraceElement(ex);
             if (element != null) {
-                throw new TemplateNotFoundException(ex.getPath(), 
+                throw new TemplateNotFoundException(ex.getPath(),
                 		Play.classes.getApplicationClass(element.getClassName()), element.getLineNumber());
             } else {
                 throw ex;


### PR DESCRIPTION
There was an issue in `PDF.resolveTemplateName()` where it wasn't able to find existing .pdf templates using `Play.getVirtualFile()` when `request.format` was set to "pdf" by the caller. So, it was always falling back to .html for template file name.
#### Example

When you have the following templates:
- app/views/Application/test.html
- app/views/Application/test.pdf

... and have a controller method:

```
public static void test() {
  request.format = "pdf";
  renderPDF();
}
```

... test.pdf template wouldn't be used.
